### PR TITLE
Process only defined tasks

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -39,10 +39,13 @@ Parser.prototype._transform = function (chunk, enc, done) {
         if (block_begin) {
             var name = block_begin[1];
             var task = this.tasks[name];
-
-            block.setTask(task);
-            block.indent = line.match(/^\s*/)[0];
-        } else if (block_end) {
+            
+            if(task) {
+                block.setTask(task);
+                block.indent = line.match(/^\s*/)[0];    
+            }
+            
+        } else if (block_end && block.inUse) {
             buffered = buffered.concat(block.compile());
         } else {
             block.inUse ? block.originals.push(line) : buffered.push(line);


### PR DESCRIPTION
This is to fix a bug where the parser strip the <!-- endbuild -->
tag regardless whether the task has been actually defined in the gulpfile.

This potentially avoid conflict if one uses gulp-html-replace with
other gulp processors, say gulp-usemin.

Update parser.js
