### PR TITLE
Added a flag for keeping placeholder tags

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,11 @@
 var Parser = require('./parser');
 var through = require('through2');
 
-module.exports = function (options, keepUnassigned) {
+module.exports = function (options, keepUnassigned, keepBlockTags) {
     var tasks = getTasks(options || {});
 
     return through.obj(function (file, enc, callback) {
-        var parser = new Parser(tasks, !!keepUnassigned);
+        var parser = new Parser(tasks, !!keepUnassigned, !!keepBlockTags);
 
         if (file.isBuffer()) {
             parser.write(file.contents);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -5,11 +5,12 @@ var Transform = require('stream').Transform;
 var Block = require('./block');
 
 
-function Parser(tasks, keepUnassigned) {
+function Parser(tasks, keepUnassigned, keepBlockTags) {
     Transform.call(this);
 
     this.tasks = tasks;
     this.keepUnassigned = keepUnassigned;
+    this.keepBlockTags = keepBlockTags;
 }
 util.inherits(Parser, Transform);
 
@@ -42,8 +43,10 @@ Parser.prototype._transform = function (chunk, enc, done) {
 
             block.setTask(task);
             block.indent = line.match(/^\s*/)[0];
+            if(this.keepBlockTags) buffered.push(line);
         } else if (block_end) {
             buffered = buffered.concat(block.compile());
+            if(this.keepBlockTags) buffered.push(line);
         } else {
             block.inUse ? block.originals.push(line) : buffered.push(line);
         }


### PR DESCRIPTION
As already discussed, this change would allow to set a keepBlockTags flag, which would preserve the start and end block tag during replace.
