### PR TITLE
Added support for multiple replace tags

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -19,8 +19,13 @@ Block.prototype.compile = function () {
     }
 
     return this.replacements.map(function (replacement) {
-        if (this.template) {
-            return this.indent + util.format(this.template, replacement);
+      if (this.template) {
+            if (Array.isArray(replacement)) {
+                replacement.unshift(this.template);
+                return this.indent + util.format.apply(util,replacement);
+            } else {
+                return this.indent + util.format(this.template, replacement);
+            }
         }
 
         var ext = replacement.split('.').pop().toLowerCase();


### PR DESCRIPTION
This "fixes" the issue #13.

Since the Array format is already supported, I thought that I'd modify a little bit the structure you proposed to be like so:

``` js
rjs: {
  src: ['data-main.js', 'require-src.js'],
  tpl: '<script src="%s"></script>'
}
```

Would output

``` html
<script src="data-main.js"></script>
<script src="require-src.js"></script>
```

Using an Array in an Array:

``` js
rjs: {
  src: [['data-main.js', 'require-src.js']],
  tpl: '<script data-main="%s" src="%s"></script>'
}
```

Would output

``` html
<script data-main="data-main.js" src="require-src.js"></script>
```

And support for multiple script output, with multiple replacement:

``` js
rjs: {
  src: [['data-main.js', 'require-src.js'], ['data-main2.js', 'require-src2.js']],
  tpl: '<script data-main="%s" src="%s"></script>'
}
```

Would output

``` html
<script data-main="data-main.js" src="require-src.js"></script>
<script data-main="data-main2.js" src="require-src2.js"></script>
```

What do you think about such a solution ? 
