### PR TITLE
relax regex for blocks

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,7 +14,7 @@ function Parser(tasks, config, file) {
 }
 util.inherits(Parser, Transform);
 
-var REGEX_BEGIN = /<!--\s*build:(\w+(-\w+)*)\s*-->/i;
+var REGEX_BEGIN = /<!--\s*build:(\S+(-\S+)*)\s*-->/i;
 var REGEX_END = /<!--\s*endbuild\s*-->/i;
 
 Parser.prototype._transform = function (chunk, enc, done) {

--- a/test/stream.js
+++ b/test/stream.js
@@ -85,6 +85,14 @@ describe('Stream mode', function () {
         compare(es.readArray(fixture), expected, stream, done);
     });
 
+    it('should work with path style task-name`s', function (done) {
+        var fixture = ['<!DOCTYPE html><head><!-- build:path/to/index.css --><link rel="stylesheet" href="_index.prefix.css"><!-- endbuild --></head>'];
+        var expected = '<!DOCTYPE html><head><link rel="stylesheet" href="path/to/index-324e23e23.css"></head>';
+
+        var stream = plugin({'path/to/index.css': 'path/to/index-324e23e23.css'});
+        compare(es.readArray(fixture), expected, stream, done);
+    });
+
     describe('Options', function () {
 
         describe('keepUnassigned', function () {


### PR DESCRIPTION
this allows you to use e.g gulp-rev`s rev-manifest.json file to replace
assets paths.

e,g, for a `rev-manifest.json` which can be passed to `htmlreplace(json)`

``` json
{
  "javascripts/apps.js": "javascripts/apps-37a1f394.js",
  "stylesheets/index.css": "stylesheets/index-b7b7ad08.css",
}
```
