### PR TITLE
Use readable-stream v2 instead of through2 v0.6

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -56,13 +56,6 @@ module.exports = {
         return tasks;
     },
 
-    extend: function (source, dest) {
-        Object.keys(dest).forEach(function (key) {
-            source[key] = dest[key];
-        });
-        return source;
-    },
-
     regexMatchAll: function (string, regexp) {
         var matches = [];
         string.replace(regexp, function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var Parser = require('./parser');
-var through = require('through2');
 var common = require('./common');
+var objectAssign = require('object-assign');
+var Parser = require('./parser');
+var Transform = require('readable-stream/transform');
 
 module.exports = function (options, userConfig) {
     var tasks = common.parseTasks(options);
@@ -16,35 +17,34 @@ module.exports = function (options, userConfig) {
     if (typeof userConfig === 'boolean') {
         config.keepUnassigned = userConfig;
     } else if (typeof userConfig === 'object') {
-        config = common.extend(config, userConfig);
+        objectAssign(config, userConfig);
     }
 
-    return through.obj(function (file, enc, callback) {
-        var parser = new Parser(tasks, config, file);
+    return new Transform({
+        objectMode: true,
+        transform: function (file, enc, callback) {
+            var parser = new Parser(tasks, config, file);
 
-        if (file.isBuffer()) {
-            parser.write(file.contents);
-            parser.end();
+            if (file.isBuffer()) {
+                parser.write(file.contents);
+                parser.end();
 
-            var contents = new Buffer(0);
-            parser.on('data', function (data) {
-                contents = Buffer.concat([contents, data]);
-            });
-            parser.once('end', function () {
-                file.contents = contents;
+                var contents = new Buffer(0);
+                parser.on('data', function (data) {
+                    contents = Buffer.concat([contents, data]);
+                });
+                parser.once('end', function () {
+                    file.contents = contents;
+                    callback(null, file);
+                });
+                return;
+            }
 
-                this.push(file);
-                return callback();
-            }.bind(this));
-        } else {
             if (file.isStream()) {
                 file.contents = file.contents.pipe(parser);
             }
 
-            this.push(file);
-            return callback();
+            callback(null, file);
         }
     });
 };
-
-

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('util');
-var Transform = require('stream').Transform;
+var Transform = require('readable-stream/transform');
 var Block = require('./block');
 var common = require('./common');
 
@@ -35,9 +35,7 @@ Parser.prototype._transform = function (chunk, enc, done) {
         content = content.replace(block.replacement, block.compile(this.tasks));
     }.bind(this));
 
-    this.push(content);
-
-    done();
+    done(null, content);
 };
 
 module.exports = Parser;

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   ],
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha --reporter spec",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- -R dot",
-    "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R dot && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "test": "mocha",
+    "coverage": "istanbul cover _mocha -- -R dot",
+    "coveralls": "istanbul cover _mocha && istanbul-coveralls"
   },
   "engines": {
     "node": ">= 0.9"
@@ -39,12 +39,12 @@
     "slash": "^1.0.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.2",
     "concat-stream": "^1.5.0",
     "from2-string": "^1.0.2",
     "gulp-util": "^3.0.5",
     "istanbul": "^0.3.14",
-    "mocha": "^2.2.5"
+    "istanbul-coveralls": "^1.0.3",
+    "mocha": "^2.2.5",
     "vinyl": "^0.5.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "node": ">= 0.9"
   },
   "dependencies": {
-    "slash": "^1.0.0",
-    "through2": "^0.6.5"
+    "object-assign": "^3.0.0",
+    "readable-stream": "^2.0.1",
+    "slash": "^1.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
-    "event-stream": "^3.3.1",
+    "concat-stream": "^1.5.0",
+    "from2-string": "^1.0.2",
     "gulp-util": "^3.0.5",
     "istanbul": "^0.3.14",
     "mocha": "^2.2.5"
+    "vinyl": "^0.5.0"
   },
   "license": "MIT"
 }

--- a/test/null.js
+++ b/test/null.js
@@ -1,22 +1,16 @@
 'use strict';
 
-var plugin = require('../lib/index');
-var gutil = require('gulp-util');
+var plugin = require('..');
+var File = require('vinyl');
 var assert = require('assert');
 
 describe('null files', function () {
     it('should be passed through', function (done) {
-
-        var fakeFile = new gutil.File({
-            contents: null
-        });
-
-        var stream = plugin();
-        stream.write(fakeFile);
-
-        stream.once('data', function (file) {
+        plugin()
+        .once('data', function (file) {
             assert(file.isNull());
             done();
-        });
+        })
+        .end(new File({contents: null}));
     });
 });

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,27 +1,27 @@
 'use strict';
 
-var plugin = require('../lib/index');
+var plugin = require('..');
 var fs = require('fs');
 var path = require('path');
-var gutil = require('gulp-util');
+var File = require('vinyl');
 var assert = require('assert');
-var es = require('event-stream');
+var concatStream = require('concat-stream');
+var stringToStream = require('from2-string');
 
 function compare(fixture, expected, stream, done) {
-    var fakeFile = new gutil.File({
+    var fakeFile = new File({
+        base: path.resolve('pages'),
+        path: path.join('pages', 'index.html'),
         contents: fixture
     });
-
-    fakeFile.base = path.join(fakeFile.cwd, 'pages');
-    fakeFile.path = path.join(fakeFile.cwd, path.join('pages', 'index.html'));
 
     stream.write(fakeFile);
 
     stream.once('data', function (file) {
         assert(file.isStream());
 
-        file.contents.pipe(es.wait(function (err, data) {
-            assert.equal(data.toString(), expected.toString());
+        file.contents.pipe(concatStream({encoding: 'string'}, function (data) {
+            assert.equal(data, expected);
             done();
         }));
     });
@@ -30,7 +30,7 @@ function compare(fixture, expected, stream, done) {
 describe('Stream mode', function () {
     it('should replace blocks', function (done) {
         var fixture = fs.createReadStream(path.join('test', 'fixture.html'));
-        var expected = fs.readFileSync(path.join('test', 'expected.html'));
+        var expected = fs.readFileSync(path.join('test', 'expected.html'), 'utf8');
 
         var stream = plugin({
             css: 'css/combined.css',
@@ -78,100 +78,100 @@ describe('Stream mode', function () {
     });
 
     it('should work with inline html', function (done) {
-        var fixture = ['<!DOCTYPE html><head><!-- build:css --><link rel="stylesheet" href="_index.prefix.css"><!-- endbuild --></head>'];
+        var fixture = '<!DOCTYPE html><head><!-- build:css --><link rel="stylesheet" href="_index.prefix.css"><!-- endbuild --></head>';
         var expected = '<!DOCTYPE html><head><link rel="stylesheet" href="css/combined.css"></head>';
 
         var stream = plugin({css: 'css/combined.css'});
-        compare(es.readArray(fixture), expected, stream, done);
+        compare(stringToStream(fixture), expected, stream, done);
     });
 
     it('should not fail if there are no build tags at all', function (done) {
-        var fixture = ['<!DOCTYPE html><head><link rel="stylesheet" href="_index.prefix.css"></head>'];
+        var fixture = '<!DOCTYPE html><head><link rel="stylesheet" href="_index.prefix.css"></head>';
 
         var stream = plugin({css: 'css/combined.css'});
-        compare(es.readArray(fixture), fixture[0], stream, done);
+        compare(stringToStream(fixture), fixture, stream, done);
     });
 
     describe('Options', function () {
 
         describe('keepUnassigned', function () {
             it('Should keep empty blocks', function (done) {
-                var fixture = ['<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>'];
+                var fixture = '<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>';
                 var expected = '<html>\nSome text\n</html>';
 
                 var stream = plugin({}, {keepUnassigned: true});
-                compare(es.readArray(fixture), expected, stream, done);
+                compare(stringToStream(fixture), expected, stream, done);
             });
 
             it('Should remove empty blocks', function (done) {
-                var fixture = ['<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>'];
+                var fixture = '<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>';
                 var expected = '<html>\n</html>';
 
                 var stream = plugin();
-                compare(es.readArray(fixture), expected, stream, done);
+                compare(stringToStream(fixture), expected, stream, done);
             });
         });
 
         describe('keepBlockTags', function () {
             it('Should keep placeholder tags without arguments', function (done) {
-                var fixture = ['<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>'];
+                var fixture = '<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>';
                 var expected = '<html>\n<!-- build:js -->\n<!-- endbuild -->\n</html>';
 
                 var stream = plugin({}, {keepBlockTags: true});
-                compare(es.readArray(fixture), expected, stream, done);
+                compare(stringToStream(fixture), expected, stream, done);
             });
 
             it('Should keep placeholder tags with arguments', function (done) {
-                var fixture = ['<html>\n<!-- build:lorem -->\nSome text\n<!-- endbuild -->\n</html>'];
+                var fixture = '<html>\n<!-- build:lorem -->\nSome text\n<!-- endbuild -->\n</html>';
                 var expected = '<html>\n<!-- build:lorem -->\nipsum\n<!-- endbuild -->\n</html>';
 
                 var stream = plugin({lorem: 'ipsum'}, {keepBlockTags: true});
-                compare(es.readArray(fixture), expected, stream, done);
+                compare(stringToStream(fixture), expected, stream, done);
             });
 
             it('Should remove placeholder tags without arguments', function (done) {
-                var fixture = ['<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>'];
+                var fixture = '<html>\n<!-- build:js -->\nSome text\n<!-- endbuild -->\n</html>';
                 var expected = '<html>\n</html>';
 
                 var stream = plugin();
-                compare(es.readArray(fixture), expected, stream, done);
+                compare(stringToStream(fixture), expected, stream, done);
             });
 
             it('Should remove placeholder tags with arguments', function (done) {
-                var fixture = ['<html>\n<!-- build:lorem -->\nSome text\n<!-- endbuild -->\n</html>'];
+                var fixture = '<html>\n<!-- build:lorem -->\nSome text\n<!-- endbuild -->\n</html>';
                 var expected = '<html>\nipsum\n</html>';
 
                 var stream = plugin({lorem: 'ipsum'});
-                compare(es.readArray(fixture), expected, stream, done);
+                compare(stringToStream(fixture), expected, stream, done);
             });
         });
 
         describe('resolvePaths', function () {
             it('Should resolve relative paths', function (done) {
-                var fixture = ['<html>\n<!-- build:js -->\n<script src="file.js"></script>\n<!-- endbuild -->\n</html>'];
+                var fixture = '<html>\n<!-- build:js -->\n<script src="file.js"></script>\n<!-- endbuild -->\n</html>';
                 var expected = '<html>\n<script src="../lib/script.js"></script>\n</html>';
 
                 var stream = plugin({js: 'lib/script.js'}, {resolvePaths: true});
-                compare(es.readArray(fixture), expected, stream, done);
+                compare(stringToStream(fixture), expected, stream, done);
             });
         });
     });
 
     describe('Legacy versions', function () {
         it('[version <1.2] should keep empty blocks (keepUnused = true)', function (done) {
-            var fixture = ['<html>\n<!-- build:js -->\nThis should not be removed\n<!-- endbuild -->\n</html>'];
+            var fixture = '<html>\n<!-- build:js -->\nThis should not be removed\n<!-- endbuild -->\n</html>';
             var expected = '<html>\nThis should not be removed\n</html>';
 
             var stream = plugin({}, true);
-            compare(es.readArray(fixture), expected, stream, done);
+            compare(stringToStream(fixture), expected, stream, done);
         });
 
         it('[version <1.2] should remove empty blocks (keepUnused = false)', function (done) {
-            var fixture = ['<html>\n<!-- build:js -->\nThis should be removed\n<!-- endbuild -->\n</html>'];
+            var fixture = '<html>\n<!-- build:js -->\nThis should be removed\n<!-- endbuild -->\n</html>';
             var expected = '<html>\n</html>';
 
             var stream = plugin();
-            compare(es.readArray(fixture), expected, stream, done);
+            compare(stringToStream(fixture), expected, stream, done);
         });
     });
 


### PR DESCRIPTION
I replaced [through2](https://github.com/rvagg/through2) v0.6 with [readable-stream](https://github.com/nodejs/readable-stream) v2.0.0. readable-stream v2.0.0 is an implementation of Streams3 that is now used in the latest Node and io.js.
