### PR TITLE
Use dirname instead of base when resolving paths.

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -58,7 +58,7 @@ Block.prototype.build = function () {
 
         if (this.config.resolvePaths) {
             var replacementPath = path.resolve(this.file.cwd, replacement);
-            replacement = path.relative(this.file.base, replacementPath);
+            replacement = path.relative(this.file.dirname, replacementPath);
             replacement = slash(replacement);
         }
 

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -14,8 +14,8 @@ function compare(fixture, expected, stream, done) {
         done();
     })
     .end(new File({
-        base: path.resolve('pages'),
-        path: path.join('pages', 'index.html'),
+        base: path.resolve('www'),
+        path: path.resolve('www', 'pages', 'index.html'),
         contents: fixture
     }));
 }
@@ -150,7 +150,7 @@ describe('Buffer mode', function () {
         describe('resolvePaths', function () {
             it('Should resolve relative paths', function (done) {
                 var fixture = '<html>\n<!-- build:js -->\n<script src="file.js"></script>\n<!-- endbuild -->\n</html>';
-                var expected = '<html>\n<script src="../lib/script.js"></script>\n</html>';
+                var expected = '<html>\n<script src="../../lib/script.js"></script>\n</html>';
 
                 var stream = plugin({js: 'lib/script.js'}, {resolvePaths: true});
                 compare(new Buffer(fixture), expected, stream, done);

--- a/test/stream.js
+++ b/test/stream.js
@@ -10,8 +10,8 @@ var stringToStream = require('from2-string');
 
 function compare(fixture, expected, stream, done) {
     var fakeFile = new File({
-        base: path.resolve('pages'),
-        path: path.join('pages', 'index.html'),
+        base: path.resolve('www'),
+        path: path.resolve('www', 'pages', 'index.html'),
         contents: fixture
     });
 
@@ -157,7 +157,7 @@ describe('Stream mode', function () {
         describe('resolvePaths', function () {
             it('Should resolve relative paths', function (done) {
                 var fixture = '<html>\n<!-- build:js -->\n<script src="file.js"></script>\n<!-- endbuild -->\n</html>';
-                var expected = '<html>\n<script src="../lib/script.js"></script>\n</html>';
+                var expected = '<html>\n<script src="../../lib/script.js"></script>\n</html>';
 
                 var stream = plugin({js: 'lib/script.js'}, {resolvePaths: true});
                 compare(stringToStream(fixture), expected, stream, done);


### PR DESCRIPTION
`'www/**/*.html'` glob gives files with base set to `'/the-current-working-directory/www/'`, as result files from subdirectories (like `'www/pages/index.html'`) won't be handled correctly: they will get paths relative to `'www/'`, not to a dir they are in.