### PR TITLE
dirname for vilyn older versions 

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -58,7 +58,7 @@ Block.prototype.build = function () {
 
         if (this.config.resolvePaths) {
             var replacementPath = path.resolve(this.file.cwd, replacement);
-            replacement = path.relative(this.file.dirname, replacementPath);
+            replacement = path.relative(path.dirname(this.file.path), replacementPath);
             replacement = slash(replacement);
         }
 


### PR DESCRIPTION
file.dirname is only available in `vinyl@0.5.0` and newer, using path.dirname to support the older versions.
By default, gulp currently uses `vinyl-fs@0.3.13` (`^0.3.0`) which uses `vinyl@0.4.6` (`^0.4.0`).