### PR TITLE
Split replacementPath by '?' before trying to search extension

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -62,12 +62,7 @@ Block.prototype.build = function () {
             replacement = slash(replacement);
         }
 
-        var ext = replacement.split('.').pop().toLowerCase();
-
-        //add build version or timestamp support
-        //some file like main.js?ts=123124
-        //some file like main.js?sha1=0a9d
-        ext = ext.split('?')[0].toLowerCase();
+        var ext = replacement.split('?')[0].toLowerCase().split('.').pop();
 
         if (ext === 'js') {
             return util.format('%s<script src="%s"></script>', this.indent, replacement);

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -27,7 +27,7 @@ describe('Buffer mode', function () {
 
         var stream = plugin({
             css: 'css/combined.css',
-            js_files: ['js/one.js', 'js/two.js?ts=123'],
+            js_files: ['js/one.js', 'js/two.js?ts=123', 'js/three.js?v=v1.5.3-1-g91cd575'],
             js_files_tpl: {
                 src: 'js/with_tpl.js',
                 tpl: '<script src="%s"></script>'

--- a/test/expected.html
+++ b/test/expected.html
@@ -9,6 +9,7 @@
 <body>
     <script src="js/one.js"></script>
     <script src="js/two.js?ts=123"></script>
+    <script src="js/three.js?v=v1.5.3-1-g91cd575"></script>
 
 <script src="js/with_tpl.js"></script>
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -34,7 +34,7 @@ describe('Stream mode', function () {
 
         var stream = plugin({
             css: 'css/combined.css',
-            js_files: ['js/one.js', 'js/two.js?ts=123'],
+            js_files: ['js/one.js', 'js/two.js?ts=123', 'js/three.js?v=v1.5.3-1-g91cd575'],
             js_files_tpl: {
                 src: 'js/with_tpl.js',
                 tpl: '<script src="%s"></script>'


### PR DESCRIPTION
Split replacementPath by '?' before trying to search extension of source file.

This fixes problem with periods in query string.
For instance, 'js/one.js?v=1.2.3.4'.