### PR TITLE
Support Vinyl files stream as replacement input

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -3,7 +3,7 @@
 var buffer = require('vinyl-buffer');
 
 function isStream(obj) {
-    return typeof obj !== 'undefined' && typeof obj.pipe === 'function' && typeof obj.on === 'function';
+    return obj && typeof obj.pipe === 'function' && typeof obj.on === 'function';
 }
 
 /**

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,28 +1,45 @@
 'use strict';
 
-var stream = require('stream');
-var reduce = require('stream-reduce');
 var buffer = require('vinyl-buffer');
 
-function fetchSrcString(src) {
+function isStream(obj) {
+    return typeof obj.pipe === 'function' && typeof obj.on === 'function';
+}
 
-    return new Promise(function (resolve, reject) {
-        if (typeof src.pipe === 'function' && typeof src.on === 'function') {
-            src
-                .pipe(buffer())
-                .pipe(reduce(function (accumulation, file) {
-                    return file.contents.toString();
-                }, ''))
-                .on('data', function (srcString) {
-                    resolve(srcString);
+/**
+ * Takes the src property of the task configuration and deeply "resolves" any vinyl file stream in it by turning
+ * it into a string.
+ *
+ * This function doesn't change the "arborescence" of the given value: all the forms with strings accepted
+ * work with vinyl file streams.
+ *
+ * @returns {Promise}
+ */
+function resolveSrcString(srcProperty) {
+    if (Array.isArray(srcProperty)) {
+        // handle multiple tag replacement
+        return Promise.all(srcProperty.map(function (item) {
+            return resolveSrcString(item);
+        }));
+    } else if (isStream(srcProperty)) {
+        return new Promise(function (resolve, reject) {
+            var strings = [];
+
+            srcProperty.pipe(buffer())
+                .on('data', function (file) {
+                    strings.push(file.contents.toString());
                 })
-                .on('error', function (error) {
+                .on('error', function(error) {
                     reject(error);
+                    this.end();
+                })
+                .once('end', function () {
+                    resolve(strings);
                 });
-        } else {
-            resolve(src);
-        }
-    });
+        });
+    } else {
+        return Promise.resolve(srcProperty);
+    }
 }
 
 module.exports = {
@@ -56,10 +73,10 @@ module.exports = {
                     var item = options[name];
 
                     if (typeof item.src !== 'undefined') {
-                        return fetchSrcString(item.src)
-                            .then(function (itemSrcString) {
-                                task.srcIsNull = itemSrcString === null;
-                                task.src = task.src.concat(itemSrcString);
+                        return resolveSrcString(item.src)
+                            .then(function (srcStrings) {
+                                task.srcIsNull = srcStrings === null;
+                                task.src = task.src.concat(srcStrings);
                                 task.tpl = item.tpl;
                             });
                     } else {

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,30 @@
 'use strict';
 
+var stream = require('stream');
+var reduce = require('stream-reduce');
+var buffer = require('vinyl-buffer');
+
+function fetchSrcString(src) {
+
+    return new Promise(function (resolve, reject) {
+        if (typeof src.pipe === 'function' && typeof src.on === 'function') {
+            src
+                .pipe(buffer())
+                .pipe(reduce(function (accumulation, file) {
+                    return file.contents.toString();
+                }, ''))
+                .on('data', function (srcString) {
+                    resolve(srcString);
+                })
+                .on('error', function (error) {
+                    reject(error);
+                });
+        } else {
+            resolve(src);
+        }
+    });
+}
+
 module.exports = {
     /**
      * tasks = {
@@ -14,46 +39,58 @@ module.exports = {
         options = options || {};
 
         var utilExtensions = /%f|%e/g;
-        var tasks = {};
+        var tasksByNames = {};
 
-        Object.keys(options).forEach(function (key) {
-            var item = options[key];
-            var src = [];
-            var tpl = null;
-            var uniqueExtensions = {};
-            var result;
-            var srcIsNull;
+        var tasksPromises = Object.keys(options).map(function (name) {
 
-            if (typeof item.src !== 'undefined') {
-                srcIsNull = item.src === null;
-                src = src.concat(item.src);
-                tpl = item.tpl;
-            } else {
-                src = src.concat(item);
-            }
-
-            while (result = utilExtensions.exec(tpl)) {
-                var type = result[0];
-                var unique = {};
-
-                if (uniqueExtensions[type]) {
-                    continue;
-                }
-
-                unique.regex = new RegExp(result[0], "g");
-                unique.value = null;
-                uniqueExtensions[type] = unique;
-            }
-
-            tasks[key] = {
-                src: src,
-                tpl: tpl,
-                uni: uniqueExtensions,
-                srcIsNull: srcIsNull
+            var task = {
+                src: [],
+                tpl: '',
+                uni: {},
+                srcIsNull: false
             };
+
+            return Promise
+                .resolve()
+                .then(function () {
+                    var item = options[name];
+
+                    if (typeof item.src !== 'undefined') {
+                        return fetchSrcString(item.src)
+                            .then(function (itemSrcString) {
+                                task.srcIsNull = itemSrcString === null;
+                                task.src = task.src.concat(itemSrcString);
+                                task.tpl = item.tpl;
+                            });
+                    } else {
+                        task.src = task.src.concat(item);
+                    }
+                })
+                .then(function () {
+                    var result;
+
+                    while (result = utilExtensions.exec(task.tpl)) {
+                        var type = result[0];
+                        var unique = {};
+
+                        if (task.uni[type]) {
+                            continue;
+                        }
+
+                        unique.regex = new RegExp(result[0], "g");
+                        unique.value = null;
+                        task.uni[type] = unique;
+                    }
+                })
+                .then(function () {
+                    tasksByNames[name] = task;
+                });
         });
 
-        return tasks;
+        return Promise.all(tasksPromises)
+            .then(function() {
+               return tasksByNames;
+        });
     },
 
     regexMatchAll: function (string, regexp) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -3,7 +3,7 @@
 var buffer = require('vinyl-buffer');
 
 function isStream(obj) {
-    return typeof obj.pipe === 'function' && typeof obj.on === 'function';
+    return typeof obj !== 'undefined' && typeof obj.pipe === 'function' && typeof obj.on === 'function';
 }
 
 /**
@@ -62,7 +62,7 @@ module.exports = {
 
             var task = {
                 src: [],
-                tpl: '',
+                tpl: null,
                 uni: {},
                 srcIsNull: false
             };

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Promise = require('bluebird');
 var buffer = require('vinyl-buffer');
 
 function isStream(obj) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -72,17 +72,14 @@ module.exports = {
                 .resolve()
                 .then(function () {
                     var item = options[name];
+                    var src = typeof item.src !== 'undefined' ? item.src : item;
 
-                    if (typeof item.src !== 'undefined') {
-                        return resolveSrcString(item.src)
-                            .then(function (srcStrings) {
-                                task.srcIsNull = srcStrings === null;
-                                task.src = task.src.concat(srcStrings);
-                                task.tpl = item.tpl;
-                            });
-                    } else {
-                        task.src = task.src.concat(item);
-                    }
+                    return resolveSrcString(src)
+                      .then(function(srcStrings) {
+                          task.srcIsNull = srcStrings === null;
+                          task.src = task.src.concat(srcStrings);
+                          task.tpl = item.tpl;
+                      });
                 })
                 .then(function () {
                     var result;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var common = require('./common');
 var Parser = require('./parser');
 
 module.exports = function (options, userConfig) {
-    var tasks = common.parseTasks(options);
+    var tasksPromise = common.parseTasks(options);
 
     var config = {
         keepUnassigned: false,
@@ -24,28 +24,33 @@ module.exports = function (options, userConfig) {
     return new Transform({
         objectMode: true,
         transform: function (file, enc, callback) {
-            var parser = new Parser(clone(tasks), config, file);
+            tasksPromise
+                .then(function (tasks) {
 
-            if (file.isBuffer()) {
-                parser.write(file.contents);
-                parser.end();
+                    var parser = new Parser(clone(tasks), config, file);
 
-                var contents = new Buffer(0);
-                parser.on('data', function (data) {
-                    contents = Buffer.concat([contents, data]);
-                });
-                parser.once('end', function () {
-                    file.contents = contents;
+                    if (file.isBuffer()) {
+                        parser.write(file.contents);
+                        parser.end();
+
+                        var contents = new Buffer(0);
+                        parser.on('data', function (data) {
+                            contents = Buffer.concat([contents, data]);
+                        });
+                        parser.once('end', function () {
+                            file.contents = contents;
+                            callback(null, file);
+                        });
+                        return;
+                    }
+
+                    if (file.isStream()) {
+                        file.contents = file.contents.pipe(parser);
+                    }
+
                     callback(null, file);
-                });
-                return;
-            }
-
-            if (file.isStream()) {
-                file.contents = file.contents.pipe(parser);
-            }
-
-            callback(null, file);
+                })
+            .catch(callback);
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "node": ">= 0.9"
   },
   "dependencies": {
+    "bluebird": "^3.1.1",
     "clone": "^1.0.2",
     "object-assign": "^4.0.1",
     "readable-stream": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "clone": "^1.0.2",
     "object-assign": "^4.0.1",
     "readable-stream": "^2.0.4",
-    "slash": "^1.0.0"
+    "slash": "^1.0.0",
+    "stream-reduce": "^1.0.3",
+    "vinyl-buffer": "^1.0.0"
   },
   "devDependencies": {
     "concat-stream": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "object-assign": "^4.0.1",
     "readable-stream": "^2.0.4",
     "slash": "^1.0.0",
-    "stream-reduce": "^1.0.3",
     "vinyl-buffer": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "istanbul": "^0.4.0",
     "istanbul-coveralls": "^1.0.3",
     "mocha": "^2.3.4",
-    "vinyl": "^1.1.0"
+    "vinyl": "^1.1.0",
+    "vinyl-source-stream": "^1.1.0"
   },
   "license": "MIT"
 }

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Everything here will be replaced
 Type: `Object` `{task-name: replacement}`
 
 * **task-name** - The name of the block in your HTML.
-* **replacement** - `String|Array|Object` The replacement. See examples below.
+* **replacement** - `String|Array|stream.Readable|Object` The replacement. See examples below.
 
 ###### Simple example:
 ```javascript
@@ -62,7 +62,7 @@ htmlreplace({
   }
 })
 ```
-* **src** - `String|Array` Same thing as in simple example.
+* **src** - `String|Array|stream.Readable` Same thing as in simple example.
 * **tpl** - `String` Template string. Uses [util.format()](http://nodejs.org/api/util.html#util_util_format_format) internally.
 
 > In the first example `%s` will be replaced with `img/avatar.png` producing `<img src="img/avatar.png" align="left">` as the result.
@@ -87,7 +87,7 @@ htmlreplace({
 })
 
 ```
-* **src** - `null|String|Array` Same as examples above but null if there are no standard replacements in the template.
+* **src** - `null|String|Array|stream.Readable` Same as examples above but null if there are no standard replacements in the template.
 * **tpl** - `String` Template string. Extended replacements do not use `util.format()` and are performed before standard replacements.
 
 > In the first example `src` is null because there are no standard replacements. `%f` is replaced with the name (without extension) of the file currently being processed. If the file being processed is `xyzzy.html` the result is `<script src="xyzzy.js"></script>`.
@@ -98,6 +98,19 @@ Valid extended replacements are:
 
 * **%f** - this will be replaced with the filename, without an extension.
 * **%e** - this will be replaced with the extension including the `.` character.
+
+###### Stream replacements:
+Everywhere a string replacement can be given, a stream of vinyl is also accepted. The content of each file will be treated as UTF-8 text and used for replacement. If the stream produces more than a file the behavior is the same as when an array is given.
+```javascript
+// Replacement is a stream
+htmlreplace({
+  cssInline: {
+    src: gulp.src('style/main.scss').pipe(sass()),
+    tpl: '<style>%s</style>'
+  }
+})
+
+```
 
 #### options
 Type: `object`

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -5,6 +5,8 @@ var fs = require('fs');
 var path = require('path');
 var File = require('vinyl');
 var assert = require('assert');
+var stringToStream = require('from2-string');
+var source = require('vinyl-source-stream');
 
 function compare(fixture, expected, stream, done) {
     stream
@@ -64,7 +66,11 @@ describe('Buffer mode', function () {
                 src: [['js/with_tpl_2vars1.js', 'js/with_tpl_2vars2.js'], ['js/with_tpl_2vars1_2.js', 'js/with_tpl_2vars2_2.js']],
                 tpl: '<script data-src="%f.data" data-main="%s" src="%s"></script>'
             },
-            'lorem-ipsum': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+            'lorem-ipsum': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            'stream-simple': stringToStream('Stream simple replacement').pipe(source('fake-vinyl.txt')),
+            'stream-advanced': {
+                src:  stringToStream('Stream advanced replacement').pipe(source('fake-vinyl.txt'))
+            }
         });
 
         compare(fixture, expected, stream, done);

--- a/test/expected.html
+++ b/test/expected.html
@@ -34,5 +34,9 @@
 <script data-src="index.data" data-main="js/with_tpl_2vars1_2.js" src="js/with_tpl_2vars2_2.js"></script>
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Stream simple replacement
+
+Stream advanced replacement
 </body>
 </html>

--- a/test/fixture.html
+++ b/test/fixture.html
@@ -52,5 +52,11 @@
 
 <!-- build:lorem-ipsum -->
 <!-- endbuild -->
+
+<!-- build:stream-simple -->
+<!-- endbuild -->
+
+<!-- build:stream-advanced -->
+<!-- endbuild -->
 </body>
 </html>

--- a/test/stream.js
+++ b/test/stream.js
@@ -7,6 +7,7 @@ var File = require('vinyl');
 var assert = require('assert');
 var concatStream = require('concat-stream');
 var stringToStream = require('from2-string');
+var source = require('vinyl-source-stream');
 
 function compare(fixture, expected, stream, done) {
     var fakeFile = new File({
@@ -71,7 +72,11 @@ describe('Stream mode', function () {
                 src: [['js/with_tpl_2vars1.js', 'js/with_tpl_2vars2.js'], ['js/with_tpl_2vars1_2.js', 'js/with_tpl_2vars2_2.js']],
                 tpl: '<script data-src="%f.data" data-main="%s" src="%s"></script>'
             },
-            'lorem-ipsum': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+            'lorem-ipsum': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            'stream-simple': stringToStream('Stream simple replacement').pipe(source('fake-vinyl.txt')),
+            'stream-advanced': {
+                src:  stringToStream('Stream advanced replacement').pipe(source('fake-vinyl.txt'))
+            }
         });
 
         compare(fixture, expected, stream, done);


### PR DESCRIPTION
Sorry for the delay, it's been a very long time :( Hope you are still interested @VFK 

It is a WIP, I still have to write unit tests and update the README but I wanted to get your feedback before moving forward.

#### What's this PR do?
It allows to pass a stream of vinyl files as input of task `src` property everywhere a `string` value is accepted.

#### What are the relevant tickets?
https://github.com/VFK/gulp-html-replace/issues/25