### PR TITLE
Adding trailing '/' to css links

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -67,7 +67,7 @@ Block.prototype.build = function () {
         if (ext === 'js') {
             return util.format('%s<script src="%s"></script>', this.indent, replacement);
         } else if (ext === 'css') {
-            return util.format('%s<link rel="stylesheet" href="%s">', this.indent, replacement);
+            return util.format('%s<link rel="stylesheet" href="%s"/>', this.indent, replacement);
         }
         return this.indent + replacement;
     }.bind(this));
@@ -75,7 +75,7 @@ Block.prototype.build = function () {
 
 Block.prototype.compile = function (tasks) {
     var task = tasks[this.taskName];
-    
+
     if (task) {
         this.replacements = task.src;
         this.template = task.tpl;

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -72,7 +72,7 @@ describe('Buffer mode', function () {
 
     it('should work with inline html', function (done) {
         var fixture = '<!DOCTYPE html><head><!-- build:css --><link rel="stylesheet" href="_index.prefix.css"><!-- endbuild --></head>';
-        var expected = '<!DOCTYPE html><head><link rel="stylesheet" href="css/combined.css"></head>';
+        var expected = '<!DOCTYPE html><head><link rel="stylesheet" href="css/combined.css"/></head>';
 
         var stream = plugin({css: 'css/combined.css'});
         compare(new Buffer(fixture), expected, stream, done);

--- a/test/expected.html
+++ b/test/expected.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Test file</title>
 
-    <link rel="stylesheet" href="css/combined.css">
+    <link rel="stylesheet" href="css/combined.css"/>
 </head>
 <body>
     <script src="js/one.js"></script>

--- a/test/stream.js
+++ b/test/stream.js
@@ -79,7 +79,7 @@ describe('Stream mode', function () {
 
     it('should work with inline html', function (done) {
         var fixture = '<!DOCTYPE html><head><!-- build:css --><link rel="stylesheet" href="_index.prefix.css"><!-- endbuild --></head>';
-        var expected = '<!DOCTYPE html><head><link rel="stylesheet" href="css/combined.css"></head>';
+        var expected = '<!DOCTYPE html><head><link rel="stylesheet" href="css/combined.css"/></head>';
 
         var stream = plugin({css: 'css/combined.css'});
         compare(stringToStream(fixture), expected, stream, done);


### PR DESCRIPTION
I’m using Thymeleaf in a Spring MVC application and the parser errors out when tags aren’t closed.
