### PR TITLE
Use path.basename as it was meant to be

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -26,9 +26,9 @@ Block.prototype.build = function () {
 
     // get the replacement strings and do replacements for extensions
     if (this.uniqueExts) {
-        var basename = path.basename(this.file.path);
-        var extname = path.extname(basename);
-        basename = basename.slice(0, basename.lastIndexOf(extname));
+        var extname = path.extname(this.file.path);
+        var basename = path.basename(this.file.path, extname);
+
         if (this.uniqueExts['%f']) {
             this.uniqueExts['%f'].value = basename;
         }


### PR DESCRIPTION
Change convoluted logic for separating the basename and extension. When I wrote this I didn't realize that path.basename() could remove the extension.

This isn't a big change - it's just something I noticed when looking at the code.