### PR TITLE
Special replacement patterns fix

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -32,7 +32,9 @@ Parser.prototype._transform = function (chunk, enc, done) {
     var matches = common.regexMatchAll(content, regex);
     matches.forEach(function (match) {
         var block = new Block(this.config, this.file, match);
-        content = content.replace(block.replacement, block.compile(this.tasks));
+        content = content.replace(block.replacement, function () {
+            return block.compile(this.tasks)
+        }.bind(this));
     }.bind(this));
 
     done(null, content);

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -70,6 +70,9 @@ describe('Buffer mode', function () {
             'stream-simple': stringToStream('Stream simple replacement').pipe(source('fake-vinyl.txt')),
             'stream-advanced': {
                 src:  stringToStream('Stream advanced replacement').pipe(source('fake-vinyl.txt'))
+            },
+            'stream-special': {
+                src: stringToStream('Stream $$ special replacement pattern').pipe(source('fake-vinyl.txt'))
             }
         });
 

--- a/test/expected.html
+++ b/test/expected.html
@@ -38,5 +38,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 Stream simple replacement
 
 Stream advanced replacement
+
+Stream $$ special replacement pattern
 </body>
 </html>

--- a/test/fixture.html
+++ b/test/fixture.html
@@ -58,5 +58,8 @@
 
 <!-- build:stream-advanced -->
 <!-- endbuild -->
+
+<!-- build:stream-special -->
+<!-- endbuild -->
 </body>
 </html>

--- a/test/stream.js
+++ b/test/stream.js
@@ -76,6 +76,9 @@ describe('Stream mode', function () {
             'stream-simple': stringToStream('Stream simple replacement').pipe(source('fake-vinyl.txt')),
             'stream-advanced': {
                 src:  stringToStream('Stream advanced replacement').pipe(source('fake-vinyl.txt'))
+            },
+            'stream-special': {
+                src: stringToStream('Stream $$ special replacement pattern').pipe(source('fake-vinyl.txt'))
             }
         });
 


### PR DESCRIPTION
The replacement string [can include](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter) special replacement patterns and it breaks output file. Specifying a function as a parameter should fix it.