### PR TITLE
Added 'useCRLF' option

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -91,7 +91,10 @@ Block.prototype.compile = function (tasks) {
     }
 
     buildResult.unshift(null);
-    buildResult.push(null);
+    
+	if (!this.config.useCRLF) {
+		buildResult.push(null);
+	}
 
     return buildResult.join(this.linefeed);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ module.exports = function (options, userConfig) {
     var config = {
         keepUnassigned: false,
         keepBlockTags: false,
-        resolvePaths: false
+        resolvePaths: false,
+		useCRLF: false
     };
 
     if (typeof userConfig === 'boolean') {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -23,6 +23,10 @@ function Parser(tasks, config, file) {
     this.tasks = tasks;
     this.config = config;
     this.file = file;
+	
+	if (this.config.useCRLF) {
+		regex = /(\r\n?)([ \t]*)(<!--\s*build:(\w+(?:-\w+)*)\s*-->)\n?([\s\S]*?)\n?(<!--\s*endbuild\s*-->)\n?/ig;
+	}
 }
 util.inherits(Parser, Transform);
 


### PR DESCRIPTION
Added a 'useCRLF' option to prevent a new linefeed appearing every time the gulp task is run on Windows machines.

Resolves #42 
