### PR TITLE
Added %d as an extended replacement for directory name

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -28,12 +28,15 @@ Block.prototype.build = function () {
     if (this.uniqueExts) {
         var extname = path.extname(this.file.path);
         var basename = path.basename(this.file.path, extname);
-
+        var dirname = path.dirname(this.file.path);
         if (this.uniqueExts['%f']) {
             this.uniqueExts['%f'].value = basename;
         }
         if (this.uniqueExts['%e']) {
             this.uniqueExts['%e'].value = extname;
+        }
+        if (this.uniqueExts['%d']) {
+            this.uniqueExts['%d'].value = dirname.split(path.sep).pop();
         }
 
         Object.keys(this.uniqueExts).forEach(function (key) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -56,7 +56,7 @@ module.exports = {
     parseTasks: function (options) {
         options = options || {};
 
-        var utilExtensions = /%f|%e/g;
+        var utilExtensions = /%f|%e|%d/g;
         var tasksByNames = {};
 
         var tasksPromises = Object.keys(options).map(function (name) {

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ Valid extended replacements are:
 
 * **%f** - this will be replaced with the filename, without an extension.
 * **%e** - this will be replaced with the extension including the `.` character.
+* **%d** - this will be replaced with the directory name.
 
 ###### Stream replacements:
 Everywhere a string replacement can be given, a stream of vinyl is also accepted. The content of each file will be treated as UTF-8 text and used for replacement. If the stream produces more than a file the behavior is the same as when an array is given.


### PR DESCRIPTION
This is my first pull request. Hopefully, everything is in line. This change would allow the use of the file's directory name in replacements. It would be helpful for multi-entry applications.

```
// Replacement based on the file being processed
// Stream contains ['\root\views\map\index.js', '\root\views\home\index.js']
htmlreplace({
  js: {
    src: null,
    tpl: '<script src="%d.%f.bundle.js"></script>'
  }
})
// Outputs: <script src="map.index.bundle.js"></script>, <script src="home.index.bundle.js"></script>
```

Please let me know if I can improve my request.
Best regards,
Joe
